### PR TITLE
fix: Issue #31 购物车改名为每日菜单，支持点击查看做法

### DIFF
--- a/client/src/views/Cart.vue
+++ b/client/src/views/Cart.vue
@@ -14,7 +14,7 @@
 
     <div class="max-w-4xl mx-auto px-4 py-6">
       <div v-if="cartItems.length === 0" class="text-center py-16">
-        <div class="text-6xl mb-4">🛒</div>
+        <div class="text-6xl mb-4">📋</div>
         <h2 class="text-xl font-semibold text-gray-800 dark:text-white mb-2">今日菜单是空的</h2>
         <p class="text-gray-500 dark:text-gray-400 mb-6">去首页选择今日的菜品吧</p>
         <button @click="$router.push('/')" class="px-6 py-3 bg-accent-500 text-white rounded-xl font-medium">
@@ -33,11 +33,11 @@
         </div>
 
         <div class="space-y-3 mb-6">
-              <div @click="goToDish(item.dish_id || item.id)" class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm flex items-center gap-4 cursor-pointer hover:shadow-md transition-shadow"
-    >
+          <div
             v-for="item in cartItems"
             :key="item.id"
-            
+            @click="goToDish(item.dish_id || item.id)"
+            class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm flex items-center gap-4 cursor-pointer hover:shadow-md transition-shadow"
           >
             <img
               :src="item.image_url || '/placeholder-dish.png'"
@@ -47,8 +47,9 @@
             <div class="flex-1">
               <h3 class="font-semibold text-gray-800 dark:text-white">{{ item.name }}</h3>
               <p class="text-sm text-gray-500 dark:text-gray-400">{{ item.category }} · {{ item.difficulty }}</p>
+              <p class="text-xs text-accent-500 mt-1">点击查看做法</p>
             </div>
-            <div class="flex items-center gap-3">
+            <div class="flex items-center gap-3" @click.stop>
               <button
                 @click="updateQuantity(item.id, item.quantity - 1)"
                 class="w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center hover:bg-gray-200 dark:hover:bg-gray-600 active:scale-90 transition-all"
@@ -84,6 +85,12 @@ const router = useRouter()
 const store = useDishStore()
 
 const cartItems = computed(() => store.cart)
+
+const goToDish = (id) => {
+  if (id) {
+    router.push(\`/dish/\${id}\`)
+  }
+}
 
 const updateQuantity = (id, quantity) => {
   store.updateQuantity(id, quantity)


### PR DESCRIPTION
## 修复内容

1. **改名**：购物车 → 每日菜单
2. **跳转功能**：点击菜品卡片可跳转到菜品详情页查看做法
3. **交互优化**：
   - 添加"点击查看做法"提示
   - 数量调整按钮添加 `@click.stop` 防止触发跳转

## 关联 Issue
- Issue #31: [Feature] 购物车改名为每日菜单，并支持查看做法